### PR TITLE
Improve block polling efficiency and reliability

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -37,8 +37,7 @@ pub fn block_to_block_distribution(
                 Err(e) => {
                     eprint!(
                         "Failed to calculate miner reward for transaction with hash: {}, error: {}",
-                        &hash,
-                        e
+                        &hash, e
                     );
                 }
             }

--- a/src/chain/convert.rs
+++ b/src/chain/convert.rs
@@ -2,7 +2,7 @@
 // use alloy_primitives::aliases::{U240, U48};
 // use shared::types::AgentPayload;
 
-// 
+//
 // pub trait OracleConverter<A> {
 //     fn convert(&self, payload: A) -> OraclePayloadV2;
 // }

--- a/src/models/distribution_analysis.rs
+++ b/src/models/distribution_analysis.rs
@@ -9,16 +9,22 @@ use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
 use anyhow::{anyhow, Result};
 
-pub fn get_prediction_distribution(block_distributions: &[BlockDistribution]) -> Result<(f64, Settlement)> {
+pub fn get_prediction_distribution(
+    block_distributions: &[BlockDistribution],
+) -> Result<(f64, Settlement)> {
     if block_distributions.is_empty() {
-        return Err(anyhow!("DistributionAnalysis model requires at least one block distribution"));
+        return Err(anyhow!(
+            "DistributionAnalysis model requires at least one block distribution"
+        ));
     }
-    
+
     let latest_block = block_distributions.last().unwrap();
 
     // Focus on most recent block for distribution analysis
     if latest_block.is_empty() {
-        return Err(anyhow!("DistributionAnalysis model requires non-empty latest block"));
+        return Err(anyhow!(
+            "DistributionAnalysis model requires non-empty latest block"
+        ));
     }
 
     // Sort buckets by gas price

--- a/src/models/last_min.rs
+++ b/src/models/last_min.rs
@@ -6,12 +6,17 @@ use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
 use anyhow::{anyhow, Result};
 
-pub fn get_prediction_last_min(block_distributions: &[BlockDistribution]) -> Result<(f64, Settlement)> {
-    let last_block_distribution = block_distributions.last()
+pub fn get_prediction_last_min(
+    block_distributions: &[BlockDistribution],
+) -> Result<(f64, Settlement)> {
+    let last_block_distribution = block_distributions
+        .last()
         .ok_or_else(|| anyhow!("LastMin model requires at least one block distribution"))?;
 
     if last_block_distribution.is_empty() {
-        return Err(anyhow!("LastMin model requires non-empty block distribution"));
+        return Err(anyhow!(
+            "LastMin model requires non-empty block distribution"
+        ));
     }
 
     let last_min = last_block_distribution

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -17,8 +17,6 @@ mod pending_floor;
 mod percentile;
 mod time_series;
 
-
-
 /// Will apply a model to a list of block distribution and return a price
 /// Block distributions are sorted oldest to newest.
 pub async fn apply_model(
@@ -76,7 +74,10 @@ mod tests {
 
         // Should return an error when no pending distribution
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires pending block distribution"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires pending block distribution"));
     }
 
     #[test]
@@ -96,13 +97,19 @@ mod tests {
         // Test empty block distributions
         let result = apply_model(&ModelKind::LastMin, &[], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires at least one block"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires at least one block"));
 
         // Test empty last block
         let empty_block = vec![];
         let result = apply_model(&ModelKind::LastMin, &[empty_block], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("non-empty block distribution"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("non-empty block distribution"));
     }
 
     #[tokio::test]
@@ -110,13 +117,19 @@ mod tests {
         // Test empty block distributions
         let result = apply_model(&ModelKind::Percentile, &[], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires at least one block"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires at least one block"));
 
         // Test blocks with no transactions
         let empty_blocks = vec![vec![], vec![]];
         let result = apply_model(&ModelKind::Percentile, &empty_blocks, None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("blocks with transactions"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("blocks with transactions"));
     }
 
     #[tokio::test]
@@ -124,13 +137,19 @@ mod tests {
         // Test empty block distributions
         let result = apply_model(&ModelKind::MovingAverage, &[], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires at least one block"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires at least one block"));
 
         // Test blocks with no transactions (should result in zero weight_sum)
         let empty_blocks = vec![vec![], vec![]];
         let result = apply_model(&ModelKind::MovingAverage, &empty_blocks, None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("blocks with transactions"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("blocks with transactions"));
     }
 
     #[tokio::test]
@@ -138,13 +157,19 @@ mod tests {
         // Test empty block distributions
         let result = apply_model(&ModelKind::AdaptiveThreshold, &[], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires at least one block"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires at least one block"));
 
         // Test blocks with no transactions
         let empty_blocks = vec![vec![], vec![]];
         let result = apply_model(&ModelKind::AdaptiveThreshold, &empty_blocks, None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("blocks with transactions"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("blocks with transactions"));
     }
 
     #[tokio::test]
@@ -152,13 +177,19 @@ mod tests {
         // Test empty block distributions
         let result = apply_model(&ModelKind::TimeSeries, &[], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires at least one block"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires at least one block"));
 
         // Test blocks with no transactions
         let empty_blocks = vec![vec![], vec![], vec![]];
         let result = apply_model(&ModelKind::TimeSeries, &empty_blocks, None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("blocks with transactions"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("blocks with transactions"));
     }
 
     #[tokio::test]
@@ -166,21 +197,36 @@ mod tests {
         // Test empty block distributions
         let result = apply_model(&ModelKind::DistributionAnalysis, &[], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires at least one block"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires at least one block"));
 
         // Test empty latest block
         let empty_block = vec![];
         let result = apply_model(&ModelKind::DistributionAnalysis, &[empty_block], None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("non-empty latest block"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("non-empty latest block"));
     }
 
     #[tokio::test]
     async fn test_models_with_valid_data() {
         let valid_block = vec![
-            Bucket { gwei: 10.0, count: 5 },
-            Bucket { gwei: 15.0, count: 3 },
-            Bucket { gwei: 8.0, count: 2 },
+            Bucket {
+                gwei: 10.0,
+                count: 5,
+            },
+            Bucket {
+                gwei: 15.0,
+                count: 3,
+            },
+            Bucket {
+                gwei: 8.0,
+                count: 2,
+            },
         ];
         let blocks = vec![valid_block.clone(), valid_block.clone()];
 

--- a/src/models/moving_average.rs
+++ b/src/models/moving_average.rs
@@ -11,7 +11,9 @@ use anyhow::{anyhow, Result};
 
 pub fn get_prediction_swma(block_distributions: &[BlockDistribution]) -> Result<(f64, Settlement)> {
     if block_distributions.is_empty() {
-        return Err(anyhow!("MovingAverage model requires at least one block distribution"));
+        return Err(anyhow!(
+            "MovingAverage model requires at least one block distribution"
+        ));
     }
     // Use up to 10 most recent blocks
     let num_blocks = 10.min(block_distributions.len());
@@ -41,13 +43,17 @@ pub fn get_prediction_swma(block_distributions: &[BlockDistribution]) -> Result<
     }
 
     if !has_transactions {
-        return Err(anyhow!("MovingAverage model requires blocks with transactions"));
+        return Err(anyhow!(
+            "MovingAverage model requires blocks with transactions"
+        ));
     }
 
     let predicted_price = if weight_sum > 0.0 {
         weighted_sum / weight_sum
     } else {
-        return Err(anyhow!("MovingAverage model requires blocks with transactions"));
+        return Err(anyhow!(
+            "MovingAverage model requires blocks with transactions"
+        ));
     };
 
     Ok((round_to_9_places(predicted_price), Settlement::Fast))

--- a/src/models/percentile.rs
+++ b/src/models/percentile.rs
@@ -9,9 +9,13 @@ use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
 use anyhow::{anyhow, Result};
 
-pub fn get_prediction_percentile(block_distributions: &[BlockDistribution]) -> Result<(f64, Settlement)> {
+pub fn get_prediction_percentile(
+    block_distributions: &[BlockDistribution],
+) -> Result<(f64, Settlement)> {
     if block_distributions.is_empty() {
-        return Err(anyhow!("Percentile model requires at least one block distribution"));
+        return Err(anyhow!(
+            "Percentile model requires at least one block distribution"
+        ));
     }
 
     let percentile = 0.75; // 75th percentile for high inclusion probability
@@ -35,7 +39,9 @@ pub fn get_prediction_percentile(block_distributions: &[BlockDistribution]) -> R
     let total_txs: u32 = all_gas_prices.iter().map(|(_, count)| *count).sum();
 
     if total_txs == 0 {
-        return Err(anyhow!("Percentile model requires blocks with transactions"));
+        return Err(anyhow!(
+            "Percentile model requires blocks with transactions"
+        ));
     }
 
     // Find the gas price at the given percentile

--- a/src/models/time_series.rs
+++ b/src/models/time_series.rs
@@ -11,9 +11,13 @@ use anyhow::{anyhow, Result};
 
 use super::moving_average::get_prediction_swma;
 
-pub fn get_prediction_time_series(block_distributions: &[BlockDistribution]) -> Result<(f64, Settlement)> {
+pub fn get_prediction_time_series(
+    block_distributions: &[BlockDistribution],
+) -> Result<(f64, Settlement)> {
     if block_distributions.is_empty() {
-        return Err(anyhow!("TimeSeries model requires at least one block distribution"));
+        return Err(anyhow!(
+            "TimeSeries model requires at least one block distribution"
+        ));
     }
     // Need more blocks for time series analysis
     let num_blocks = 20.min(block_distributions.len());
@@ -57,7 +61,9 @@ pub fn get_prediction_time_series(block_distributions: &[BlockDistribution]) -> 
     }
 
     if median_prices.is_empty() {
-        return Err(anyhow!("TimeSeries model requires blocks with transactions"));
+        return Err(anyhow!(
+            "TimeSeries model requires blocks with transactions"
+        ));
     }
 
     // Simple linear regression

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -391,7 +391,10 @@ mod tests {
 
         let result = parse_transactions(&block_data);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("missing valid gas pricing"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("missing valid gas pricing"));
     }
 
     #[test]
@@ -408,7 +411,10 @@ mod tests {
 
         let result = parse_transactions(&block_data);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("missing valid gas pricing"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("missing valid gas pricing"));
     }
 
     #[test]
@@ -429,13 +435,13 @@ mod tests {
 
         let result = parse_transactions(&block_data).unwrap();
         assert_eq!(result.len(), 2);
-        
+
         // First transaction (legacy)
         assert_eq!(result[0].hash, "0x4444444444444444");
         assert_eq!(result[0].gas_price, Some(5000000000));
         assert_eq!(result[0].max_fee_per_gas, None);
         assert_eq!(result[0].max_priority_fee_per_gas, None);
-        
+
         // Second transaction (EIP-1559)
         assert_eq!(result[1].hash, "0x5555555555555555");
         assert_eq!(result[1].gas_price, None);
@@ -456,7 +462,10 @@ mod tests {
 
         let result = parse_transactions(&block_data);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Missing or invalid transaction hash"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Missing or invalid transaction hash"));
     }
 
     #[test]
@@ -477,6 +486,9 @@ mod tests {
 
         let result = parse_transactions(&block_data);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Missing or invalid transactions array"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Missing or invalid transactions array"));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -175,6 +175,23 @@ impl SystemNetworkKey {
             } => 137,
         }
     }
+
+    pub fn to_block_time(&self) -> u64 {
+        match self {
+            SystemNetworkKey {
+                system: System::Ethereum,
+                network: Network::Mainnet,
+            } => 12000,
+            SystemNetworkKey {
+                system: System::Base,
+                network: Network::Mainnet,
+            } => 2000,
+            SystemNetworkKey {
+                system: System::Polygon,
+                network: Network::Mainnet,
+            } => 2000,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]


### PR DESCRIPTION
This PR refactors the block polling mechanism to use deterministic timing based on
network block times rather than dynamically calculating estimates. The changes improve
reliability by eliminating timing drift and ensure consistent block discovery across
different networks.

### Key Changes

- Deterministic block timing: Replace dynamic block time estimation with fixed
network-specific block times (Ethereum: 12s, Base/Polygon: 2s)
- Smart polling intervals: Calculate wait times based on actual time elapsed since last
 block to prevent drift
- Improved logging: Add debug logs for monitoring polling behavior and warnings for
missed blocks
- Non-blocking predictions: Spawn prediction tasks asynchronously to prevent blocking
the main polling loop
- Retry mechanism: Poll every 250ms when expecting a new block to catch blocks as soon
as they're available

### Benefits

- More reliable block discovery with reduced chance of missing blocks
- Better performance through non-blocking prediction generation
- Easier debugging with improved logging and clear warnings for anomalies
- Consistent behavior across different network types