### PR TITLE
Update model functions to return FromBlock value

### DIFF
--- a/src/models/adaptive_threshold.rs
+++ b/src/models/adaptive_threshold.rs
@@ -1,3 +1,4 @@
+use crate::models::{FromBlock, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
 use anyhow::{anyhow, Result};
@@ -15,7 +16,8 @@ How it works: This algorithm finds the minimum gas price included in each recent
 
 pub fn get_prediction_adaptive_threshold(
     block_distributions: &[BlockDistribution],
-) -> Result<(f64, Settlement)> {
+    latest_block: u64,
+) -> Result<(Prediction, Settlement, FromBlock)> {
     // Handle empty input
     if block_distributions.is_empty() {
         return Err(anyhow!(
@@ -86,5 +88,9 @@ pub fn get_prediction_adaptive_threshold(
         .to_f64()
         .unwrap();
 
-    Ok((round_to_9_places(predicted_price), Settlement::Fast))
+    Ok((
+        round_to_9_places(predicted_price),
+        Settlement::Fast,
+        latest_block + 1,
+    ))
 }

--- a/src/models/last_min.rs
+++ b/src/models/last_min.rs
@@ -2,13 +2,15 @@
 Simply takes the minimum of the last block.
 */
 
+use crate::models::{FromBlock, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
 use anyhow::{anyhow, Result};
 
 pub fn get_prediction_last_min(
     block_distributions: &[BlockDistribution],
-) -> Result<(f64, Settlement)> {
+    latest_block: u64,
+) -> Result<(Prediction, Settlement, FromBlock)> {
     let last_block_distribution = block_distributions
         .last()
         .ok_or_else(|| anyhow!("LastMin model requires at least one block distribution"))?;
@@ -25,5 +27,5 @@ pub fn get_prediction_last_min(
         .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
         .unwrap_or(0.0);
 
-    Ok((round_to_9_places(last_min), Settlement::Fast))
+    Ok((round_to_9_places(last_min), Settlement::Fast, latest_block + 1))
 }

--- a/src/models/moving_average.rs
+++ b/src/models/moving_average.rs
@@ -5,11 +5,12 @@ This approach calculates a weighted average of recent gas prices, giving more we
 How it works: This algorithm calculates the average gas price for each block, weighs them by recency, and produces a weighted average. It's simple and works well when gas prices are relatively stable.
 */
 
+use crate::models::{FromBlock, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
 use anyhow::{anyhow, Result};
 
-pub fn get_prediction_swma(block_distributions: &[BlockDistribution]) -> Result<(f64, Settlement)> {
+pub fn get_prediction_swma(block_distributions: &[BlockDistribution], latest_block: u64) -> Result<(Prediction, Settlement, FromBlock)> {
     if block_distributions.is_empty() {
         return Err(anyhow!(
             "MovingAverage model requires at least one block distribution"
@@ -56,5 +57,5 @@ pub fn get_prediction_swma(block_distributions: &[BlockDistribution]) -> Result<
         ));
     };
 
-    Ok((round_to_9_places(predicted_price), Settlement::Fast))
+    Ok((round_to_9_places(predicted_price), Settlement::Fast, latest_block + 1))
 }

--- a/src/models/percentile.rs
+++ b/src/models/percentile.rs
@@ -5,13 +5,15 @@ This approach analyzes the distribution of gas prices across recent blocks and s
 How it works: This algorithm collects all gas prices from recent blocks, sorts them, and finds the price at a specific percentile (75th in this case). This is particularly effective during periods of high volatility, as it targets a price that would have included 75% of recent transactions.
 */
 
+use crate::models::{FromBlock, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
 use anyhow::{anyhow, Result};
 
 pub fn get_prediction_percentile(
     block_distributions: &[BlockDistribution],
-) -> Result<(f64, Settlement)> {
+    latest_block: u64,
+) -> Result<(Prediction, Settlement, FromBlock)> {
     if block_distributions.is_empty() {
         return Err(anyhow!(
             "Percentile model requires at least one block distribution"
@@ -57,5 +59,5 @@ pub fn get_prediction_percentile(
         }
     }
 
-    Ok((round_to_9_places(percentile_price), Settlement::Fast))
+    Ok((round_to_9_places(percentile_price), Settlement::Fast, latest_block + 1))
 }


### PR DESCRIPTION
## Summary

This PR updates all gas price prediction model functions to return a `FromBlock` value, indicating which block number the prediction applies to. This enables more precise tracking of when predictions should take effect.

## Changes

### Type Updates
- Added `FromBlock` type alias (`u64`) to the models module
- Updated `apply_model` function signature to accept `latest_block` parameter
- Changed all model function return types from `(Prediction, Settlement)` to `(Prediction, Settlement, FromBlock)`

### Model Function Updates
All prediction functions now:
- Accept a `latest_block: u64` parameter
- Return `latest_block + 1` as the `FromBlock` value
- Maintain their existing prediction logic unchanged

Updated models:
- `adaptive_threshold::get_prediction_adaptive_threshold`
- `distribution_analysis::get_prediction_distribution`
- `last_min::get_prediction_last_min`
- `moving_average::get_prediction_swma`
- `percentile::get_prediction_percentile`
- `time_series::get_prediction_time_series`
- `pending_floor::get_prediction_pending_floor`

### Additional Fixes
- Fixed variable shadowing in `distribution_analysis.rs` (renamed local `latest_block` to `latest_block_distribution`)
- Updated `time_series.rs` fallback call to `get_prediction_swma` to include the new parameter

### Test Updates
- All model tests updated to pass `latest_block` parameter (using value `100` for tests)
- Test assertions updated to handle 3-tuple returns
- Added assertions to verify `from_block` values are correct (`latest_block + 1`)

## Impact

This change allows the gas agent to:
1. Specify exactly which block a prediction applies to
2. Better coordinate predictions with block timing
3. Provide clearer semantics for when predictions take effect

All existing functionality is preserved - the only change is the addition of the `FromBlock` return value.

## Testing

- [x] All existing tests pass
- [x] Tests updated to verify correct `FromBlock` values
- [x] Cargo build succeeds without warnings
- [x] No breaking changes to prediction logic