### PR TITLE
Change pending floor settlement to Fast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "gas-agent"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gas-agent"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 
 [profile.release]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -29,13 +29,19 @@ pub async fn apply_model(
     latest_block: u64,
 ) -> Result<(Prediction, Settlement, FromBlock)> {
     match model {
-        ModelKind::AdaptiveThreshold => get_prediction_adaptive_threshold(block_distributions, latest_block),
-        ModelKind::DistributionAnalysis => get_prediction_distribution(block_distributions, latest_block),
+        ModelKind::AdaptiveThreshold => {
+            get_prediction_adaptive_threshold(block_distributions, latest_block)
+        }
+        ModelKind::DistributionAnalysis => {
+            get_prediction_distribution(block_distributions, latest_block)
+        }
         ModelKind::MovingAverage => get_prediction_swma(block_distributions, latest_block),
         ModelKind::Percentile => get_prediction_percentile(block_distributions, latest_block),
         ModelKind::TimeSeries => get_prediction_time_series(block_distributions, latest_block),
         ModelKind::LastMin => get_prediction_last_min(block_distributions, latest_block),
-        ModelKind::PendingFloor => get_prediction_pending_floor(pending_block_distribution, latest_block),
+        ModelKind::PendingFloor => {
+            get_prediction_pending_floor(pending_block_distribution, latest_block)
+        }
     }
 }
 
@@ -61,15 +67,19 @@ mod tests {
             },
         ];
 
-        let (price, settlement, from_block) =
-            apply_model(&ModelKind::PendingFloor, &[], Some(pending_distribution), 100)
-                .await
-                .unwrap();
+        let (price, settlement, from_block) = apply_model(
+            &ModelKind::PendingFloor,
+            &[],
+            Some(pending_distribution),
+            100,
+        )
+        .await
+        .unwrap();
 
         // Should be minimum (5.0) + 1 wei (0.000000001)
         let expected = 5.0 + 0.000000001;
         assert_eq!(price, crate::utils::round_to_9_places(expected));
-        assert_eq!(settlement, Settlement::Immediate);
+        assert_eq!(settlement, Settlement::Fast);
         assert_eq!(from_block, 101);
     }
 

--- a/src/models/pending_floor.rs
+++ b/src/models/pending_floor.rs
@@ -51,7 +51,11 @@ pub fn get_prediction_pending_floor(
     // Add 1 wei to the minimum price to ensure inclusion
     let prediction = min_price + ONE_WEI_IN_GWEI;
 
-    Ok((round_to_9_places(prediction), Settlement::Immediate, latest_block + 1))
+    Ok((
+        round_to_9_places(prediction),
+        Settlement::Fast,
+        latest_block + 1,
+    ))
 }
 
 #[cfg(test)]
@@ -80,12 +84,13 @@ mod tests {
             },
         ];
 
-        let (price, settlement, from_block) = get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
+        let (price, settlement, from_block) =
+            get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
 
         // Should be minimum (8.0) + 1 wei (0.000000001)
         let expected = 8.0 + ONE_WEI_IN_GWEI;
         assert_eq!(price, round_to_9_places(expected));
-        assert_eq!(settlement, Settlement::Immediate);
+        assert_eq!(settlement, Settlement::Fast);
         assert_eq!(from_block, 101);
     }
 
@@ -122,12 +127,13 @@ mod tests {
             count: 10,
         }];
 
-        let (price, settlement, from_block) = get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
+        let (price, settlement, from_block) =
+            get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
 
         // Should be 25.5 + 1 wei
         let expected = 25.5 + ONE_WEI_IN_GWEI;
         assert_eq!(price, round_to_9_places(expected));
-        assert_eq!(settlement, Settlement::Immediate);
+        assert_eq!(settlement, Settlement::Fast);
         assert_eq!(from_block, 101);
     }
 
@@ -144,12 +150,13 @@ mod tests {
             },
         ];
 
-        let (price, settlement, from_block) = get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
+        let (price, settlement, from_block) =
+            get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
 
         // Should be 0.0 + 1 wei
         let expected = 0.0 + ONE_WEI_IN_GWEI;
         assert_eq!(price, round_to_9_places(expected));
-        assert_eq!(settlement, Settlement::Immediate);
+        assert_eq!(settlement, Settlement::Fast);
         assert_eq!(from_block, 101);
     }
 
@@ -160,12 +167,13 @@ mod tests {
             count: 1,
         }];
 
-        let (price, settlement, from_block) = get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
+        let (price, settlement, from_block) =
+            get_prediction_pending_floor(Some(pending_distribution), 100).unwrap();
 
         // Should be properly rounded to 9 decimal places
         let expected = 1.123456789 + ONE_WEI_IN_GWEI;
         assert_eq!(price, round_to_9_places(expected));
-        assert_eq!(settlement, Settlement::Immediate);
+        assert_eq!(settlement, Settlement::Fast);
         assert_eq!(from_block, 101);
     }
 }


### PR DESCRIPTION
We only have a Fast settlement evaluation function deployed for evaluating estimates, so we can change the pending floor model to use `Settlement::Fast` instead for now.