### PR TITLE
Replace anyhow with concrete ModelError type for model predictions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "~1.44.0", features = ["full"] }
 serde = { version = "~1.0.219", features = ["derive"] }
 serde_json = "~1.0.133"
 anyhow = "~1.0.93"
+thiserror = "~2.0.9"
 clap = { version = "~4.5.37", features = ["derive", "env"] }
 strum_macros = "~0.26.4"
 strum = "~0.26.3"

--- a/src/models/adaptive_threshold.rs
+++ b/src/models/adaptive_threshold.rs
@@ -1,7 +1,6 @@
-use crate::models::{FromBlock, Prediction};
+use crate::models::{FromBlock, ModelError, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
-use anyhow::{anyhow, Result};
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
     Decimal,
@@ -17,11 +16,11 @@ How it works: This algorithm finds the minimum gas price included in each recent
 pub fn get_prediction_adaptive_threshold(
     block_distributions: &[BlockDistribution],
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
     // Handle empty input
     if block_distributions.is_empty() {
-        return Err(anyhow!(
-            "AdaptiveThreshold model requires at least one block distribution"
+        return Err(ModelError::insufficient_data(
+            "AdaptiveThreshold model requires at least one block distribution",
         ));
     }
 
@@ -51,8 +50,8 @@ pub fn get_prediction_adaptive_threshold(
     }
 
     if min_included_prices.is_empty() {
-        return Err(anyhow!(
-            "AdaptiveThreshold model requires blocks with transactions"
+        return Err(ModelError::insufficient_data(
+            "AdaptiveThreshold model requires blocks with transactions",
         ));
     }
 

--- a/src/models/distribution_analysis.rs
+++ b/src/models/distribution_analysis.rs
@@ -5,18 +5,17 @@ This approach analyzes the cumulative distribution function (CDF) of gas prices 
 How it works: This algorithm analyzes how gas prices are distributed in the most recent block, constructing a cumulative distribution function. It then identifies the "sweet spot" where the rate of change in the CDF decreases significantly. This is often where many transactions are being included, representing an efficient gas price.
 */
 
-use crate::models::{FromBlock, Prediction};
+use crate::models::{FromBlock, ModelError, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
-use anyhow::{anyhow, Result};
 
 pub fn get_prediction_distribution(
     block_distributions: &[BlockDistribution],
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
     if block_distributions.is_empty() {
-        return Err(anyhow!(
-            "DistributionAnalysis model requires at least one block distribution"
+        return Err(ModelError::insufficient_data(
+            "DistributionAnalysis model requires at least one block distribution",
         ));
     }
 
@@ -24,8 +23,8 @@ pub fn get_prediction_distribution(
 
     // Focus on most recent block for distribution analysis
     if latest_block_distribution.is_empty() {
-        return Err(anyhow!(
-            "DistributionAnalysis model requires non-empty latest block"
+        return Err(ModelError::insufficient_data(
+            "DistributionAnalysis model requires non-empty latest block",
         ));
     }
 

--- a/src/models/errors.rs
+++ b/src/models/errors.rs
@@ -1,0 +1,42 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ModelError {
+    #[error("Missing required data: {message}")]
+    MissingData { message: String },
+
+    #[error("Insufficient data for computation: {message}")]
+    InsufficientData { message: String },
+
+    #[error("Invalid data provided: {message}")]
+    InvalidData { message: String },
+
+    #[error("Computation failed: {message}")]
+    ComputationError { message: String },
+}
+
+impl ModelError {
+    pub fn missing_data(message: impl Into<String>) -> Self {
+        Self::MissingData {
+            message: message.into(),
+        }
+    }
+
+    pub fn insufficient_data(message: impl Into<String>) -> Self {
+        Self::InsufficientData {
+            message: message.into(),
+        }
+    }
+
+    pub fn invalid_data(message: impl Into<String>) -> Self {
+        Self::InvalidData {
+            message: message.into(),
+        }
+    }
+
+    pub fn computation_error(message: impl Into<String>) -> Self {
+        Self::ComputationError {
+            message: message.into(),
+        }
+    }
+}

--- a/src/models/last_min.rs
+++ b/src/models/last_min.rs
@@ -2,22 +2,21 @@
 Simply takes the minimum of the last block.
 */
 
-use crate::models::{FromBlock, Prediction};
+use crate::models::{FromBlock, ModelError, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
-use anyhow::{anyhow, Result};
 
 pub fn get_prediction_last_min(
     block_distributions: &[BlockDistribution],
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
-    let last_block_distribution = block_distributions
-        .last()
-        .ok_or_else(|| anyhow!("LastMin model requires at least one block distribution"))?;
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
+    let last_block_distribution = block_distributions.last().ok_or_else(|| {
+        ModelError::insufficient_data("LastMin model requires at least one block distribution")
+    })?;
 
     if last_block_distribution.is_empty() {
-        return Err(anyhow!(
-            "LastMin model requires non-empty block distribution"
+        return Err(ModelError::insufficient_data(
+            "LastMin model requires non-empty block distribution",
         ));
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,7 +1,6 @@
 use crate::distribution::BlockDistribution;
 use crate::types::{ModelKind, Settlement};
 use adaptive_threshold::get_prediction_adaptive_threshold;
-use anyhow::Result;
 use distribution_analysis::get_prediction_distribution;
 use last_min::get_prediction_last_min;
 use moving_average::get_prediction_swma;
@@ -11,11 +10,14 @@ use time_series::get_prediction_time_series;
 
 mod adaptive_threshold;
 mod distribution_analysis;
+mod errors;
 mod last_min;
 mod moving_average;
 mod pending_floor;
 mod percentile;
 mod time_series;
+
+pub use errors::ModelError;
 
 pub type Prediction = f64;
 pub type FromBlock = u64;
@@ -27,7 +29,7 @@ pub async fn apply_model(
     block_distributions: &[BlockDistribution],
     pending_block_distribution: Option<BlockDistribution>,
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
     match model {
         ModelKind::AdaptiveThreshold => {
             get_prediction_adaptive_threshold(block_distributions, latest_block)

--- a/src/models/moving_average.rs
+++ b/src/models/moving_average.rs
@@ -5,18 +5,17 @@ This approach calculates a weighted average of recent gas prices, giving more we
 How it works: This algorithm calculates the average gas price for each block, weighs them by recency, and produces a weighted average. It's simple and works well when gas prices are relatively stable.
 */
 
-use crate::models::{FromBlock, Prediction};
+use crate::models::{FromBlock, ModelError, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
-use anyhow::{anyhow, Result};
 
 pub fn get_prediction_swma(
     block_distributions: &[BlockDistribution],
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
     if block_distributions.is_empty() {
-        return Err(anyhow!(
-            "MovingAverage model requires at least one block distribution"
+        return Err(ModelError::insufficient_data(
+            "MovingAverage model requires at least one block distribution",
         ));
     }
     // Use up to 10 most recent blocks
@@ -47,16 +46,16 @@ pub fn get_prediction_swma(
     }
 
     if !has_transactions {
-        return Err(anyhow!(
-            "MovingAverage model requires blocks with transactions"
+        return Err(ModelError::insufficient_data(
+            "MovingAverage model requires blocks with transactions",
         ));
     }
 
     let predicted_price = if weight_sum > 0.0 {
         weighted_sum / weight_sum
     } else {
-        return Err(anyhow!(
-            "MovingAverage model requires blocks with transactions"
+        return Err(ModelError::insufficient_data(
+            "MovingAverage model requires blocks with transactions",
         ));
     };
 

--- a/src/models/pending_floor.rs
+++ b/src/models/pending_floor.rs
@@ -13,28 +13,27 @@ How it works:
 4. Returns this as the optimal price for immediate settlement
 */
 
-use crate::models::{FromBlock, Prediction};
+use crate::models::{FromBlock, ModelError, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
-use anyhow::{anyhow, Result};
 
 const ONE_WEI_IN_GWEI: f64 = 0.000000001; // 1 wei
 
 pub fn get_prediction_pending_floor(
     pending_block_distribution: Option<BlockDistribution>,
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
     // If no pending block distribution is available, return an error
     let Some(pending_distribution) = pending_block_distribution else {
-        return Err(anyhow!(
-            "PendingFloor model requires pending block distribution data"
+        return Err(ModelError::missing_data(
+            "PendingFloor model requires pending block distribution data",
         ));
     };
 
     // If the pending distribution is empty, return an error
     if pending_distribution.is_empty() {
-        return Err(anyhow!(
-            "PendingFloor model requires non-empty pending block distribution"
+        return Err(ModelError::insufficient_data(
+            "PendingFloor model requires non-empty pending block distribution",
         ));
     }
 

--- a/src/models/percentile.rs
+++ b/src/models/percentile.rs
@@ -5,18 +5,17 @@ This approach analyzes the distribution of gas prices across recent blocks and s
 How it works: This algorithm collects all gas prices from recent blocks, sorts them, and finds the price at a specific percentile (75th in this case). This is particularly effective during periods of high volatility, as it targets a price that would have included 75% of recent transactions.
 */
 
-use crate::models::{FromBlock, Prediction};
+use crate::models::{FromBlock, ModelError, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
-use anyhow::{anyhow, Result};
 
 pub fn get_prediction_percentile(
     block_distributions: &[BlockDistribution],
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
     if block_distributions.is_empty() {
-        return Err(anyhow!(
-            "Percentile model requires at least one block distribution"
+        return Err(ModelError::insufficient_data(
+            "Percentile model requires at least one block distribution",
         ));
     }
 
@@ -41,8 +40,8 @@ pub fn get_prediction_percentile(
     let total_txs: u32 = all_gas_prices.iter().map(|(_, count)| *count).sum();
 
     if total_txs == 0 {
-        return Err(anyhow!(
-            "Percentile model requires blocks with transactions"
+        return Err(ModelError::insufficient_data(
+            "Percentile model requires blocks with transactions",
         ));
     }
 

--- a/src/models/time_series.rs
+++ b/src/models/time_series.rs
@@ -5,20 +5,19 @@ This approach uses simple linear regression to identify trends in gas prices and
 How it works: This algorithm calculates the median gas price for each block, performs linear regression to identify the trend, and extrapolates to predict the next value. It's particularly useful when gas prices show a consistent trend over time (either increasing or decreasing).
 */
 
-use crate::models::{FromBlock, Prediction};
+use crate::models::{FromBlock, ModelError, Prediction};
 use crate::types::Settlement;
 use crate::{distribution::BlockDistribution, utils::round_to_9_places};
-use anyhow::{anyhow, Result};
 
 use super::moving_average::get_prediction_swma;
 
 pub fn get_prediction_time_series(
     block_distributions: &[BlockDistribution],
     latest_block: u64,
-) -> Result<(Prediction, Settlement, FromBlock)> {
+) -> Result<(Prediction, Settlement, FromBlock), ModelError> {
     if block_distributions.is_empty() {
-        return Err(anyhow!(
-            "TimeSeries model requires at least one block distribution"
+        return Err(ModelError::insufficient_data(
+            "TimeSeries model requires at least one block distribution",
         ));
     }
     // Need more blocks for time series analysis
@@ -63,8 +62,8 @@ pub fn get_prediction_time_series(
     }
 
     if median_prices.is_empty() {
-        return Err(anyhow!(
-            "TimeSeries model requires blocks with transactions"
+        return Err(ModelError::insufficient_data(
+            "TimeSeries model requires blocks with transactions",
         ));
     }
 


### PR DESCRIPTION
- Add thiserror dependency for structured error handling
- Create ModelError enum with MissingData, InsufficientData, InvalidData, and ComputationError variants
- Update apply_model signature to return concrete ModelError instead of anyhow::Result
- Convert all model functions to use structured error types
- Modify create_prediction to gracefully handle InsufficientData errors with debug logging
- Return early for insufficient data scenarios without propagating errors