### PR TITLE
Add mock collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ name = "mock-collector"
 version = "0.1.0"
 dependencies = [
  "axum",
- "chrono",
+ "gas-agent",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1795,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2140,6 +2196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2231,19 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mock-collector"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3457,6 +3532,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,6 +4073,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4026,6 +4112,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+members = [
+    ".",
+    "crates/mock-collector"
+]
+
 [package]
 name = "gas-agent"
 version = "0.1.1"

--- a/crates/mock-collector/Cargo.toml
+++ b/crates/mock-collector/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mock-collector"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1.44", features = ["full"] }
+axum = "0.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/crates/mock-collector/Cargo.toml
+++ b/crates/mock-collector/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+gas-agent = { path = "../.." }
 tokio = { version = "1.44", features = ["full"] }
 axum = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-chrono = { version = "0.4", features = ["serde"] }

--- a/crates/mock-collector/src/main.rs
+++ b/crates/mock-collector/src/main.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::post,
     Router,
 };
+use gas_agent::AgentPayload;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use tracing::{info, warn};
@@ -15,47 +16,6 @@ struct AgentSubmission {
     payload: AgentPayload,
     signature: String,
     network_signature: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct AgentPayload {
-    schema_version: String,
-    from_block: u64,
-    settlement: Settlement,
-    timestamp: chrono::DateTime<chrono::Utc>,
-    system: System,
-    network: Network,
-    unit: PriceUnit,
-    price: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum System {
-    Ethereum,
-    Base,
-    Polygon,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum Network {
-    Mainnet,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum Settlement {
-    Immediate,
-    Fast,
-    Medium,
-    Slow,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum PriceUnit {
-    Wei,
 }
 
 async fn handle_agent_publish(

--- a/crates/mock-collector/src/main.rs
+++ b/crates/mock-collector/src/main.rs
@@ -1,8 +1,5 @@
 use axum::{
-    extract::rejection::JsonRejection,
-    http::StatusCode,
-    response::IntoResponse,
-    routing::post,
+    extract::rejection::JsonRejection, http::StatusCode, response::IntoResponse, routing::post,
     Router,
 };
 use gas_agent::AgentPayload;
@@ -30,12 +27,21 @@ async fn handle_agent_publish(
             info!("Network:        {:?}", submission.payload.network);
             info!("From Block:     {}", submission.payload.from_block);
             info!("Settlement:     {:?}", submission.payload.settlement);
-            info!("Price:          {} {:?}", submission.payload.price, submission.payload.unit);
+            info!(
+                "Price:          {} {:?}",
+                submission.payload.price, submission.payload.unit
+            );
             info!("Timestamp:      {}", submission.payload.timestamp);
             info!("Schema Version: {}", submission.payload.schema_version);
             info!("───────────────────────────────────────────────────────────────");
-            info!("Signature:         {}...", &submission.signature[..20.min(submission.signature.len())]);
-            info!("Network Signature: {}...", &submission.network_signature[..20.min(submission.network_signature.len())]);
+            info!(
+                "Signature:         {}...",
+                &submission.signature[..20.min(submission.signature.len())]
+            );
+            info!(
+                "Network Signature: {}...",
+                &submission.network_signature[..20.min(submission.network_signature.len())]
+            );
             info!("═══════════════════════════════════════════════════════════════");
             (StatusCode::OK, "OK".to_string())
         }
@@ -50,7 +56,10 @@ async fn handle_agent_publish(
                 warn!("Details: {}", err.body_text());
             }
             warn!("═══════════════════════════════════════════════════════════════");
-            (StatusCode::BAD_REQUEST, format!("Invalid payload: {}", rejection))
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid payload: {}", rejection),
+            )
         }
     }
 }

--- a/crates/mock-collector/src/main.rs
+++ b/crates/mock-collector/src/main.rs
@@ -1,0 +1,121 @@
+use axum::{
+    extract::rejection::JsonRejection,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::post,
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use tracing::{info, warn};
+
+/// The payload structure sent by the gas agent
+#[derive(Debug, Deserialize, Serialize)]
+struct AgentSubmission {
+    payload: AgentPayload,
+    signature: String,
+    network_signature: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AgentPayload {
+    schema_version: String,
+    from_block: u64,
+    settlement: Settlement,
+    timestamp: chrono::DateTime<chrono::Utc>,
+    system: System,
+    network: Network,
+    unit: PriceUnit,
+    price: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum System {
+    Ethereum,
+    Base,
+    Polygon,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Network {
+    Mainnet,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Settlement {
+    Immediate,
+    Fast,
+    Medium,
+    Slow,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum PriceUnit {
+    Wei,
+}
+
+async fn handle_agent_publish(
+    payload: Result<axum::Json<AgentSubmission>, JsonRejection>,
+) -> impl IntoResponse {
+    match payload {
+        Ok(axum::Json(submission)) => {
+            info!("═══════════════════════════════════════════════════════════════");
+            info!("RECEIVED AGENT SUBMISSION");
+            info!("═══════════════════════════════════════════════════════════════");
+            info!("System:         {:?}", submission.payload.system);
+            info!("Network:        {:?}", submission.payload.network);
+            info!("From Block:     {}", submission.payload.from_block);
+            info!("Settlement:     {:?}", submission.payload.settlement);
+            info!("Price:          {} {:?}", submission.payload.price, submission.payload.unit);
+            info!("Timestamp:      {}", submission.payload.timestamp);
+            info!("Schema Version: {}", submission.payload.schema_version);
+            info!("───────────────────────────────────────────────────────────────");
+            info!("Signature:         {}...", &submission.signature[..20.min(submission.signature.len())]);
+            info!("Network Signature: {}...", &submission.network_signature[..20.min(submission.network_signature.len())]);
+            info!("═══════════════════════════════════════════════════════════════");
+            (StatusCode::OK, "OK".to_string())
+        }
+        Err(rejection) => {
+            warn!("═══════════════════════════════════════════════════════════════");
+            warn!("INVALID PAYLOAD RECEIVED");
+            warn!("═══════════════════════════════════════════════════════════════");
+            warn!("Error: {}", rejection);
+            if let JsonRejection::JsonDataError(ref err) = rejection {
+                warn!("Details: {}", err.body_text());
+            } else if let JsonRejection::JsonSyntaxError(ref err) = rejection {
+                warn!("Details: {}", err.body_text());
+            }
+            warn!("═══════════════════════════════════════════════════════════════");
+            (StatusCode::BAD_REQUEST, format!("Invalid payload: {}", rejection))
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .init();
+
+    let app = Router::new()
+        .route("/v0/agents", post(handle_agent_publish))
+        .fallback(|req: axum::http::Request<axum::body::Body>| async move {
+            warn!("Unhandled request: {} {}", req.method(), req.uri());
+            (StatusCode::NOT_FOUND, "Not Found")
+        });
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
+    info!("Mock Collector listening on http://{}", addr);
+    info!("Expecting POST requests at http://{}/v0/agents", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/src/chain/encode.rs
+++ b/src/chain/encode.rs
@@ -83,15 +83,12 @@ mod tests {
     use alloy::primitives::aliases::{U240, U48};
 
     use super::*;
-    use crate::logs::init_logs;
-
-    // This ensures metrics are initialized exactly once
+    // This ensures tracing is initialized exactly once for tests
     static INIT: Once = Once::new();
 
     fn setup() {
         INIT.call_once(|| {
-            // Initialize metrics for testing
-            init_logs();
+            let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+//! Gas Agent library - shared types for the gas agent ecosystem.
+
+mod chain;
+mod types;
+
+pub use types::AgentPayload;

--- a/src/types.rs
+++ b/src/types.rs
@@ -265,6 +265,7 @@ impl SystemNetworkKey {
         }
     }
 
+    #[allow(dead_code)] // Used by agent binary only
     pub fn to_block_time(&self) -> u64 {
         match self {
             SystemNetworkKey {

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 use strum_macros::{Display, EnumString};
 
+#[allow(dead_code)] // Used by binary
 #[derive(Debug, Clone, EnumString, Display, Deserialize, Serialize)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
@@ -25,6 +26,7 @@ pub enum ModelKind {
     PendingFloor,
 }
 
+#[allow(dead_code)] // Used by binary
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(from = "String")]


### PR DESCRIPTION
### Add Mock Collector

Adds a mock collector service for local development and testing of the gas agent.

### Changes

- **New crate: `mock-collector`** - A lightweight HTTP server that receives and logs agent submissions at `POST /v0/agents`. Useful for testing the agent without connecting to a real collector.

- **New library target** - Exposes `AgentPayload` from `src/lib.rs` so the mock-collector (and other crates) can deserialize agent submissions.

### Additional Changes

- **Fixed test compilation** - Tests in `src/chain/encode.rs` previously relied on `crate::logs::init_logs()` which isn't available from the library crate root. Replaced with a self-contained test logger using `tracing_subscriber::fmt().with_test_writer()`.

- **Suppressed dead code warnings** - Added `#[allow(dead_code)]` to `ModelKind`, `AgentKind`, and `SystemNetworkKey::to_block_time()` since these are only used by the binary, not the library.

### Usage

```bash
# Run the mock collector
cargo run -p mock-collector

# Listens on http://localhost:3000/v0/agents